### PR TITLE
Fix typos in manifest.json

### DIFF
--- a/custom_components/thames_water/manifest.json
+++ b/custom_components/thames_water/manifest.json
@@ -14,6 +14,6 @@
   "codeowners": [
     "@ale770"
   ],
-  "documentation": "hhttps://github.com/ale770/ha-thames-water",
-  "issue_tracker": "hhttps://github.com/ale770/ha-thames-water/issues"
+  "documentation": "https://github.com/ale770/ha-thames-water",
+  "issue_tracker": "https://github.com/ale770/ha-thames-water/issues"
 }


### PR DESCRIPTION
Replaces `hhttps` with `https`