### PR TITLE
Use correct precision for cost entering

### DIFF
--- a/custom_components/thames_water/number.py
+++ b/custom_components/thames_water/number.py
@@ -42,7 +42,7 @@ class ThamesWaterLiterCost(ThamesWaterEntity, NumberEntity):
     _attr_native_unit_of_measurement = "GBP/L"
     _attr_native_max_value = 1.0
     _attr_native_min_value = 0.00005
-    _attr_native_step = 0.00005
+    _attr_native_step = 0.0000001
     _attr_icon = "mdi:currency-gbp"
     _attr_mode = NumberMode.BOX
 


### PR DESCRIPTION
Before the change the system insists on rounding to the nearest 0.00005 pound, not letting enter the correct liter cost.

<img width="1134" height="579" alt="image" src="https://github.com/user-attachments/assets/5d068f83-3cc3-42ba-89e7-2487b47d3fb8" />
