### PR TITLE
Bump Thames Water manifest version to 1.3.1

### DIFF
--- a/custom_components/thames_water/manifest.json
+++ b/custom_components/thames_water/manifest.json
@@ -2,7 +2,7 @@
   "domain": "thames_water",
   "name": "Thames Water",
   "integration_type": "hub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "config_flow": true,
   "requirements": [
   ],


### PR DESCRIPTION
### Motivation
- Update integration version metadata to `1.3.1` for the Thames Water integration.

### Description
- Change `version` field in `custom_components/thames_water/manifest.json` from `1.3.0` to `1.3.1`.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e4053078832f928a4534f280f980)